### PR TITLE
made `destroy_image` take a reference to `Allocation` because `Alloca…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,7 @@ impl Allocator {
     /// ```
     ///
     /// It it safe to pass null as `image` and/or `allocation`.
-    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: Allocation) {
+    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: &Allocation) {
         ffi::vmaDestroyImage(self.internal, image, allocation.0);
     }
     /// Flushes memory of given set of allocations."]


### PR DESCRIPTION
Made `destroy_image` take a reference to `Allocation`.

## Why?

Because `Allocation` doesn't implement clone, copy or default, you run into problems when trying to implement `Drop` for a struct with `Allocation` members...

```rust
impl Drop for Image {
    fn drop(&mut self) {
        unsafe {
            self.memory_allocator
                .destroy_image(self.image_handle, self.memory_allocation);
        }
    }
}
```

Results in the following error:
```error[E0507]: cannot move out of `self.memory_allocation` which is behind a mutable reference```

Using a reference (as was the case in the previous blame of `destroy_image`) fixes this.

## Why not upstream?

I like your fork better haha. No prob if you don't agree with this change though.
