### PR TITLE
Make free and destroy functions take mutable reference to `Allocation`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,7 @@ impl Allocator {
     /// ```
     ///
     /// It it safe to pass null as `image` and/or `allocation`.
-    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: Allocation) {
+    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: &Allocation) {
         ffi::vmaDestroyImage(self.internal, image, allocation.0);
     }
     /// Flushes memory of given set of allocations."]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl Allocator {
 
     /// Frees memory previously allocated using `Allocator::allocate_memory`,
     /// `Allocator::allocate_memory_for_buffer`, or `Allocator::allocate_memory_for_image`.
-    pub unsafe fn free_memory(&self, allocation: Allocation) {
+    pub unsafe fn free_memory(&self, allocation: &mut Allocation) {
         ffi::vmaFreeMemory(self.internal, allocation.0);
     }
 
@@ -202,7 +202,7 @@ impl Allocator {
     /// It may be internally optimized to be more efficient than calling 'Allocator::free_memory` `allocations.len()` times.
     ///
     /// Allocations in 'allocations' slice can come from any memory pools and types.
-    pub unsafe fn free_memory_pages(&self, allocations: &[Allocation]) {
+    pub unsafe fn free_memory_pages(&self, allocations: &mut [Allocation]) {
         ffi::vmaFreeMemoryPages(
             self.internal,
             allocations.len(),
@@ -491,7 +491,7 @@ impl Allocator {
     /// ```
     ///
     /// It it safe to pass null as `image` and/or `allocation`.
-    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: &Allocation) {
+    pub unsafe fn destroy_image(&self, image: ash::vk::Image, allocation: &mut Allocation) {
         ffi::vmaDestroyImage(self.internal, image, allocation.0);
     }
     /// Flushes memory of given set of allocations."]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -165,7 +165,7 @@ fn create_gpu_buffer() {
     };
 
     unsafe {
-        let (buffer, allocation) = allocator
+        let (buffer, mut allocation) = allocator
             .create_buffer(
                 &ash::vk::BufferCreateInfo::builder()
                     .size(16 * 1024)
@@ -179,7 +179,7 @@ fn create_gpu_buffer() {
             .unwrap();
         let allocation_info = allocator.get_allocation_info(&allocation);
         assert_eq!(allocation_info.mapped_data, std::ptr::null_mut());
-        allocator.destroy_buffer(buffer, allocation);
+        allocator.destroy_buffer(buffer, &mut allocation);
     }
 }
 
@@ -195,7 +195,7 @@ fn create_cpu_buffer_preferred() {
         ..Default::default()
     };
     unsafe {
-        let (buffer, allocation) = allocator
+        let (buffer, mut allocation) = allocator
             .create_buffer(
                 &ash::vk::BufferCreateInfo::builder()
                     .size(16 * 1024)
@@ -209,7 +209,7 @@ fn create_cpu_buffer_preferred() {
             .unwrap();
         let allocation_info = allocator.get_allocation_info(&allocation);
         assert_ne!(allocation_info.mapped_data, std::ptr::null_mut());
-        allocator.destroy_buffer(buffer, allocation);
+        allocator.destroy_buffer(buffer, &mut allocation);
     }
 }
 
@@ -245,10 +245,10 @@ fn create_gpu_buffer_pool() {
 
         let pool = allocator.create_pool(&pool_info).unwrap();
 
-        let (buffer, allocation) = pool.create_buffer(&buffer_info, &allocation_info).unwrap();
+        let (buffer, mut allocation) = pool.create_buffer(&buffer_info, &allocation_info).unwrap();
         let allocation_info = allocator.get_allocation_info(&allocation);
         assert_ne!(allocation_info.mapped_data, std::ptr::null_mut());
-        allocator.destroy_buffer(buffer, allocation);
+        allocator.destroy_buffer(buffer, &mut allocation);
     }
 }
 
@@ -267,7 +267,7 @@ fn test_gpu_stats() {
         assert_eq!(stats_1.total.statistics.allocationCount, 0);
         assert_eq!(stats_1.total.statistics.allocationBytes, 0);
 
-        let (buffer, allocation) = allocator
+        let (buffer, mut allocation) = allocator
             .create_buffer(
                 &ash::vk::BufferCreateInfo::builder()
                     .size(16 * 1024)
@@ -285,7 +285,7 @@ fn test_gpu_stats() {
         assert_eq!(stats_2.total.statistics.allocationCount, 1);
         assert_eq!(stats_2.total.statistics.allocationBytes, 16 * 1024);
 
-        allocator.destroy_buffer(buffer, allocation);
+        allocator.destroy_buffer(buffer, &mut allocation);
 
         let stats_3 = allocator.calculate_statistics().unwrap();
         assert_eq!(stats_3.total.statistics.blockCount, 1);


### PR DESCRIPTION
Made free and destroy functions take a mutable reference to `Allocation`, similar to what was already done to `destroy_buffer`. Also updated the tests to work with this change.

## Why?

Because `Allocation` doesn't implement clone, copy or default, you run into problems when trying to implement `Drop` for a struct with `Allocation` members...

```rust
impl Drop for Image {
    fn drop(&mut self) {
        unsafe {
            self.memory_allocator
                .destroy_image(self.image_handle, self.memory_allocation);
        }
    }
}
```

Results in the following error:
```error[E0507]: cannot move out of `self.memory_allocation` which is behind a mutable reference```

Using a reference (as was the case in the previous blame of `destroy_image`) fixes this.

## Why not upstream?

I like your fork better haha. No prob if you don't agree with this change though.
